### PR TITLE
Time setup

### DIFF
--- a/NixieClock.ino
+++ b/NixieClock.ino
@@ -6,11 +6,51 @@ int UP = 2;
 int DOWN = 3;
 int PUSH = 4;
 uint8_t PIN = 7;
+
+// 6 digits is whole clock with hours, minutes and SECONDS
+// can be 4. Only hours nad minutes
+// when only 4 segments will be used, it will automaticaly change
+// maximum state on rotary encoder from 7 to 6
 uint8_t DIGITS = 6;
 
 RTC_DS3231 rtc;
-NixieDigit digit = NixieDigit(PIN, DIGITS, 8);
-RotaryEncoder encoder = RotaryEncoder(UP, DOWN, PUSH);
+NixieDigit digit = NixieDigit(PIN, DIGITS, 8); // startu brightness is 80 from rang 0 - 250
+RotaryEncoder encoder = RotaryEncoder(UP, DOWN, PUSH, DIGITS == 6 ? 7 : 6);
+
+/**
+ * Setup the sketch
+ */
+void setup()
+{
+    Serial.begin(115200);
+
+    attachInterrupt(0, serviceRotaryInterupt, CHANGE);
+    attachInterrupt(1, serviceRotaryInterupt, CHANGE);
+
+    // Name: Cyan Cornflower Blue
+    // hex: #1D8ECE
+    digit.SetColor(29, 142, 206);
+    digit.Begin();
+
+    // start RTC
+    rtc.begin();
+}
+
+void loop()
+{
+    encoder.Read();
+
+    if (encoder.state == NONE)
+    {
+        writeClock();
+    }
+    else
+    {
+        setBrightness();
+        setColors();
+        setTime();
+    }
+}
 
 /**
  * Write the clock to the segments
@@ -29,37 +69,9 @@ void serviceRotaryInterupt()
 }
 
 /**
- * Setup the sketch
+ * Set up segments brightness
  */
-void setup()
-{
-    Serial.begin(115200);
-
-    attachInterrupt(0, serviceRotaryInterupt, CHANGE);
-    attachInterrupt(1, serviceRotaryInterupt, CHANGE);
-
-    digit.SetColor(170, 85, 133);
-    digit.Begin();
-    // start RTC
-    rtc.begin();
-}
-
-void loop()
-{
-    encoder.Read();
-
-    if (encoder.state == NONE)
-    {
-        writeClock();
-    }
-    else
-    {
-        handlingBrightness();
-        handlingColors();
-    }
-}
-
-void handlingBrightness()
+void setBrightness()
 {
     if (encoder.state == BRIGHTNESS)
     {
@@ -69,7 +81,10 @@ void handlingBrightness()
     }
 }
 
-void handlingColors()
+/**
+ * Set up color of all segments by each part of RGB
+ */
+void setColors()
 {
     RGB color;
 
@@ -78,20 +93,53 @@ void handlingColors()
         color = digit.GetColor();
         encoder.SetVolume(color.red, COLOR_RED);
         digit.SetColor(encoder.Volume, color.green, color.blue);
-        digit.ShowColorNumber(encoder.Volume);
+        digit.ShowNumber(encoder.Volume);
     }
     if (encoder.state == COLOR_GREEN)
     {
         color = digit.GetColor();
         encoder.SetVolume(color.green, COLOR_GREEN);
         digit.SetColor(color.red, encoder.Volume, color.blue);
-        digit.ShowColorNumber(encoder.Volume);
+        digit.ShowNumber(encoder.Volume);
     }
     if (encoder.state == COLOR_BLUE)
     {
         color = digit.GetColor();
         encoder.SetVolume(color.blue, COLOR_BLUE);
         digit.SetColor(color.red, color.green, encoder.Volume);
-        digit.ShowColorNumber(encoder.Volume);
+        digit.ShowNumber(encoder.Volume);
+    }
+}
+
+/**
+ * Set up the time of the clock
+ */
+void setTime()
+{
+    DateTime timeStamp;
+
+    if (encoder.state == TIME_HOURS)
+    {
+        timeStamp = digit.GetTime();
+        encoder.SetVolume(timeStamp.hour(), TIME_HOURS);
+        digit.SetTime(encoder.Volume, rtc, digit.HOURS);
+        Serial.println(encoder.Volume);
+        digit.ShowNumber(encoder.Volume);
+    }
+    else if (encoder.state == TIME_MINUTES)
+    {
+        timeStamp = digit.GetTime();
+        encoder.SetVolume(timeStamp.minute(), TIME_MINUTES);
+        digit.SetTime(encoder.Volume, rtc, digit.MINUTES);
+        Serial.println(encoder.Volume);
+        digit.ShowNumber(encoder.Volume);
+    }
+    else if (encoder.state == TIME_SECONDS)
+    {
+        timeStamp = digit.GetTime();
+        encoder.SetVolume(timeStamp.second(), TIME_SECONDS);
+        digit.SetTime(encoder.Volume, rtc, digit.SECONDS);
+        Serial.println(encoder.Volume);
+        digit.ShowNumber(encoder.Volume);
     }
 }

--- a/lib/NixieDigit/src/NixieDigit.cpp
+++ b/lib/NixieDigit/src/NixieDigit.cpp
@@ -11,46 +11,14 @@
  * Constructor
  * @param dataPin - pin on which data is comming to the class
  * @param numberOfSegments - number of segmets we use for our clock
- * @param bright - led diods brightness
+ * @param bright - led diods brightness It is conversion of 0 - 250 range. It has 25 position on rotary encoder
+ *                 each state is multiplied by 10.
  */
 NixieDigit::NixieDigit(uint8_t dataPin, uint8_t numberOfSegments, uint8_t bright)
 {
     brightness = bright;
     _pixels = Adafruit_NeoPixel(numberOfSegments * 20, dataPin, NEO_GRB + NEO_KHZ800);
     _pixels.setBrightness(brightness * 10);
-}
-
-/**
- * Control two segments for hour / minutes / seconds
- * @param digit - 0 / 2 / 4 means heours / minutes / seconds
- * @param value - number which should be show
- */
-void NixieDigit::Digit(uint8_t digit, uint8_t value)
-{
-    uint8_t number = (digit * 20) + (value * 2);
-    _pixels.setPixelColor(number, _pixels.Color(_color.red, _color.green, _color.blue));
-    _pixels.setPixelColor(number + 1, _pixels.Color(_color.red, _color.green, _color.blue));
-}
-
-/**
- * turn on appropriate leds
- * @param value - number of time to show up
- * @param pos - number position 0 / 2 / 4 - means segments 0|1 for hours / 2|3 for minutes / 4|5 for seconds
- */
-void NixieDigit::ShowNumber(uint16_t value, uint8_t pos)
-{
-    if (value >= 10)
-    {
-        Digit(pos, (value / 10) % 10);
-        pos++;
-    }
-    else
-    {
-        Digit(pos, 0 % 10); // leading zero number
-        pos++;
-    }
-
-    Digit(pos, value % 10);
 }
 
 /**
@@ -62,22 +30,31 @@ void NixieDigit::ShowTime(DateTime t)
     _time = t;
 
     Clear();
-    ShowNumber(_time.hour(), 0);
-    ShowNumber(_time.minute(), 2);
-    ShowNumber(_time.second(), 4);
+    _ShowNumber(_time.hour(), 0);
+    _ShowNumber(_time.minute(), 2);
+    _ShowNumber(_time.second(), 4);
     Show();
 }
 
-void NixieDigit::ShowColorNumber(uint8_t num)
+/**
+ * Shows number represented in decimal format on first three segments
+ * It is used for RGB setup or Time setup.
+ * Converts a decimal number of the input to the led position on the  first
+ * three segments. Hundreds on the first, dozens on the second and units on the third
+ * @param num - can bee decimal number in the range of 0 - 999
+ */
+void NixieDigit::ShowNumber(uint8_t num)
 {
+    // class with segment setup
     SegmentToNumberConvertor number = SegmentToNumberConvertor();
-
+    // convert number to three segments
     Segments seg = number.Convert(num);
 
     uint8_t first = seg.array[0];
     uint8_t second = seg.array[1];
     uint8_t third = seg.array[2];
 
+    // set up the segments with numbers
     Clear();
     _pixels.setPixelColor(first, _pixels.Color(_color.red, _color.green, _color.blue));
     _pixels.setPixelColor(first + 1, _pixels.Color(_color.red, _color.green, _color.blue));
@@ -86,48 +63,6 @@ void NixieDigit::ShowColorNumber(uint8_t num)
     _pixels.setPixelColor(third, _pixels.Color(_color.red, _color.green, _color.blue));
     _pixels.setPixelColor(third + 1, _pixels.Color(_color.red, _color.green, _color.blue));
     Show();
-}
-
-void NixieDigit::BlinkSegment(Segment segment)
-{
-    Clear();
-
-    switch (segment)
-    {
-    case HOURS:
-        ShowNumber(_time.hour(), 0);
-        break;
-    case MINUTES:
-        ShowNumber(_time.minute(), 2);
-        break;
-    case SECONDS:
-        ShowNumber(_time.second(), 4);
-        break;
-    default:
-        break;
-    }
-
-    Show();
-}
-
-/**
- * Render time on all segmenst with delay
- * @param delayTime - delay between clear and show
- * @param repeat - How many times will be repeated
- */
-void NixieDigit::BlinkingAll(long delayTime, uint8_t repeat)
-{
-    for (int i = 0; i < repeat; i++)
-    {
-        Serial.print("Iteration: ");
-        Serial.println(i);
-
-        _pixels.setBrightness(0);
-        ShowTime(_time);
-        delay(delayTime);
-        _pixels.setBrightness(brightness * 10);
-        ShowTime(_time);
-    }
 }
 
 /**
@@ -160,13 +95,11 @@ void NixieDigit::Begin()
  * @param green - Green color
  * @param blue - Blue color
  */
-RGB NixieDigit::SetColor(uint8_t red, uint8_t green, uint8_t blue)
+void NixieDigit::SetColor(uint8_t red, uint8_t green, uint8_t blue)
 {
     _color.red = red;
     _color.green = green;
     _color.blue = blue;
-
-    return _color;
 }
 
 /**
@@ -181,9 +114,78 @@ void NixieDigit::SetBrightness(uint8_t value)
 }
 
 /**
- * Get current color of leds
+ * Set each part of time (Hours, Minutes, Seconds)
+ * @param value - number which will be set to the RTC
+ * @param rtc - object of the RTC
+ * @param segment - represents segment which is going to be setup
+ */
+void NixieDigit::SetTime(uint8_t value, RTC_DS3231 &rtc, Segment segment)
+{
+    _time = rtc.now();
+
+    if (segment == HOURS)
+    {
+        _time = DateTime(_time.year(), _time.month(), _time.day(), value, _time.minute(), _time.second());
+    }
+    else if (segment == MINUTES)
+    {
+        _time = DateTime(_time.year(), _time.month(), _time.day(), _time.hour(), value, _time.second());
+    }
+    else if (segment == SECONDS)
+    {
+        _time = DateTime(_time.year(), _time.month(), _time.day(), _time.hour(), _time.minute(), value);
+    }
+
+    rtc.adjust(_time);
+}
+
+/**
+ * Get current color of leds when the
+ * setting has been started
  */
 RGB NixieDigit::GetColor()
 {
     return _color;
+}
+
+/**
+ * Get the inner snapshot of the time when
+ * the settings has been started
+ */
+DateTime NixieDigit::GetTime()
+{
+    return _time;
+}
+
+/**
+ * Control two segments for hour / minutes / seconds
+ * @param digit - 0 / 2 / 4 means heours / minutes / seconds
+ * @param value - number which should be show
+ */
+void NixieDigit::_Digit(uint8_t digit, uint8_t value)
+{
+    uint8_t number = (digit * 20) + (value * 2);
+    _pixels.setPixelColor(number, _pixels.Color(_color.red, _color.green, _color.blue));
+    _pixels.setPixelColor(number + 1, _pixels.Color(_color.red, _color.green, _color.blue));
+}
+
+/**
+ * turn on appropriate leds
+ * @param value - number of time to show up
+ * @param pos - number position 0 / 2 / 4 - means segments 0|1 for hours / 2|3 for minutes / 4|5 for seconds
+ */
+void NixieDigit::_ShowNumber(uint16_t value, uint8_t pos)
+{
+    if (value >= 10)
+    {
+        _Digit(pos, (value / 10) % 10);
+        pos++;
+    }
+    else
+    {
+        _Digit(pos, 0 % 10); // leading zero number
+        pos++;
+    }
+
+    _Digit(pos, value % 10);
 }

--- a/lib/NixieDigit/src/NixieDigit.h
+++ b/lib/NixieDigit/src/NixieDigit.h
@@ -22,6 +22,7 @@ struct RGB
 class NixieDigit
 {
   public:
+    // Segment definition
     enum Segment
     {
         HOURS,
@@ -30,24 +31,24 @@ class NixieDigit
     };
     uint8_t brightness;
     NixieDigit(uint8_t dataPin, uint8_t numberOfSegments, uint8_t brightness);
-    RGB SetColor(uint8_t value, uint8_t green, uint8_t blue);
-    RGB GetColor();
-    void ShowTime(DateTime t);
-    void ShowColorNumber(uint8_t num);
+    void Begin();
     void Clear();
     void Show();
-    void Begin();
+    RGB GetColor();
+    DateTime GetTime();
+    void SetColor(uint8_t value, uint8_t green, uint8_t blue);
     void SetBrightness(uint8_t brightness);
-    void BlinkingAll(long delayTime, uint8_t repeat);
+    void SetTime(uint8_t value, RTC_DS3231 &rtc, Segment segment);
+    void ShowTime(DateTime t);
+    void ShowNumber(uint8_t num);
 
   private:
     DateTime _time;
     RGB _color;
     Adafruit_NeoPixel _pixels;
     Segment _segment;
-    void Digit(uint8_t digit, uint8_t value);
-    void ShowNumber(uint16_t value, uint8_t pos);
-    void BlinkSegment(Segment segment);
+    void _Digit(uint8_t digit, uint8_t value);
+    void _ShowNumber(uint16_t value, uint8_t pos);
 };
 
 #endif

--- a/lib/RotaryEncoder/src/RotaryEncoder.h
+++ b/lib/RotaryEncoder/src/RotaryEncoder.h
@@ -6,15 +6,23 @@
 #ifndef RotaryEncoder_h
 #define RotaryEncoder_h
 
+/**
+ * Definition of encoder limits.
+ * Each limit is automaticaly set up on encoder
+ * based setting state
+ */
 enum EncoderLimits
 {
     COLOR_LIMIT = 255,
     BRIGHTNESS_LIMIT = 25,
-    HOURS_LIMIT = 24,
+    HOURS_LIMIT = 23,
     MINUTES_LIMIT = 59,
     SECONDS_LIMIT = 59
 };
 
+/**
+ * Definition of setting state
+ */
 enum State
 {
     NONE,
@@ -32,10 +40,10 @@ class RotaryEncoder
   public:
     State state;
     uint8_t Volume;
-    RotaryEncoder(uint8_t up, uint8_t down, uint8_t push);
+    RotaryEncoder(uint8_t up, uint8_t down, uint8_t push, uint8_t maxSettingState);
     void ServiceInterrupt();
     void Read();
-    bool SetVolume(uint8_t volume, State state);
+    void SetVolume(uint8_t volume, State state);
 
   private:
     uint8_t _up;
@@ -48,8 +56,7 @@ class RotaryEncoder
     bool _confirmed;
     long _lastBouncedTime;
     long _debounceDelay = 60;
-    bool Confirm(uint8_t seconds, State s);
-    uint8_t SetEncoderLimit(State s);
+    uint8_t _SetEncoderLimit(State s);
 };
 
 #endif


### PR DESCRIPTION
- change max rotary encoder state because of time set up
-- 7 states is max when 6 segments are placed. When we use only 4 segments then state will be automatically reduced from 7 to 6
- Code refactor and some methods deletedet